### PR TITLE
Update CODEOWNERS: replace legacy dittotools team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,4 +3,4 @@
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 #
 
-* @getditto/dittotools
+* @getditto/networking @getditto/sdk-kotlin-engineers


### PR DESCRIPTION
## Summary

- Replace legacy `@getditto/dittotools` team with `@getditto/networking` and `@getditto/sdk-kotlin-engineers` in CODEOWNERS
- The `dittotools` team is a legacy team that no longer reflects current ownership
- This repo needs both networking expertise (Wi-Fi Aware transport) and Kotlin app expertise